### PR TITLE
Add memoization

### DIFF
--- a/React/src/components/Home.js
+++ b/React/src/components/Home.js
@@ -136,12 +136,9 @@ const SubjectEditor = ({ data }) => {
     const { state, action } = useContext(DataContext);
 
     const changes = state.changes
-    const subjects = useMemo(() => {
-        let results = changes[0] && changes[0].data && changes[0].data.Subjects ?
-            changes[0].data.Subjects :
-            data.data.Subjects ? [...data.data.Subjects] : [];
-        return results;
-    }, [changes, data]);
+    const subjects = useMemo(() => changes[0]?.data?.Subjects ?
+    changes[0].data.Subjects :
+    data.data.Subjects ? [...data.data.Subjects] : [], [changes, data]);
 
     const onSaved = useCallback((e) => {
         let validationResult = true;

--- a/React/src/components/Home.js
+++ b/React/src/components/Home.js
@@ -140,14 +140,12 @@ const SubjectEditor = ({ data }) => {
         let results = changes[0] && changes[0].data && changes[0].data.Subjects ?
             changes[0].data.Subjects :
             data.data.Subjects ? [...data.data.Subjects] : [];
-        console.log('calculate_memo_subjects');
         return results;
     }, [changes, data]);
 
     const onSaved = useCallback((e) => {
-
         let validationResult = true;
-
+        
         if (changes.length === 0)
             changes.push({ data: { Subjects: subjects }, key: state.editRowKey, type: "update" })
         else

--- a/React/src/utils.js
+++ b/React/src/utils.js
@@ -2,6 +2,7 @@ import applyChanges from 'devextreme/data/apply_changes';
 
 function reducer(state, { type, payload }) {
     let newData;
+    console.log(type, payload)
     switch (type) {
         case "Saving":
             if (!payload.data)

--- a/React/src/utils.js
+++ b/React/src/utils.js
@@ -2,7 +2,6 @@ import applyChanges from 'devextreme/data/apply_changes';
 
 function reducer(state, { type, payload }) {
     let newData;
-    console.log(type, payload)
     switch (type) {
         case "Saving":
             if (!payload.data)


### PR DESCRIPTION
I have to add more hooks and dependencies to fix the following issue:

- Edit the existing row (e.g. row 1)
- Start editing an inner grid
- Save changes

Actual Results:

Changes are saved and works but you can notice that the main grid displays another template under the popup edit form (editCellComponent was re-initialized). This side-effect occurs because  an inner DataGrid is re-created and exists in other edit modes.

Expected Results:

No additional initializations